### PR TITLE
CI: Use 2.6.2, 2.5.5, 2.4.6; drop EOL'd 2.3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: required
 language: ruby
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.6.2
+  - 2.5.5
+  - 2.4.6
 
 services:
   - docker


### PR DESCRIPTION
This PR updates the CI matrix to include 2.6 - and drops 2.3.