### PR TITLE
Allow sync producers to be cached between calls.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--backtrace

--- a/README.md
+++ b/README.md
@@ -55,11 +55,7 @@ $ gem install phobos
 
 ### <a name="upgrade-notes"></a> Upgrade Notes
 
-Version 1.8.2 introduced a new `persistent_connections` setting for
-regular producers. This reduces the number of connections used to
-produce messages and you should consider setting it to true. This does
-require a manual shutdown call - 
-please see [Producers with persistent connections](#persistent-connection).
+Version 1.8.2 introduced a new `persistent_connections` setting for regular producers. This reduces the number of connections used to produce messages and you should consider setting it to true. This does require a manual shutdown call -  please see [Producers with persistent connections](#persistent-connection).
 
 ## <a name="usage"></a> Usage
 

--- a/README.md
+++ b/README.md
@@ -314,13 +314,15 @@ end
 
 Since the handler life cycle is managed by the Listener, it will make sure the producer is properly closed before it stops. When calling the producer outside a handler remember, you need to shutdown them manually before you close the application. Use the class method `async_producer_shutdown` to safely shutdown the producer.
 
+By default, regular producers will automatically shut themselves down after every `publish` call. You can change this behavior (which increases speed) by setting the `cache_sync_producer` config in `phobos.yml`. When set, regular producers behave identically to async producers and will also need to be shutdown manually using the `sync_producer_shutdown` method.
+
 Without configuring the Kafka client, the producers will create a new one when needed (once per thread). To disconnect from kafka call `kafka_client.close`.
 
 ```ruby
 # This method will block until everything is safely closed
 MyProducer
   .producer
-  .async_producer_shutdown
+  .async_producer_shutdown # and/or sync_producer_shutdown if regular producers are cached
 
 MyProducer
   .producer

--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -60,11 +60,11 @@ producer:
   # if greater than zero, the number of seconds between automatic message
   # deliveries. Only used for async_producer
   delivery_interval: 0
-  # Set this to true to cache the sync producer between publish calls.
+  # Set this to true to keep the producer connection between publish calls.
   # This can speed up subsequent messages by around 30%, but it does mean
   # that you need to manually call sync_producer_shutdown before exiting,
   # similar to async_producer_shutdown.
-  cache_sync_producer: false
+  persistent_connections: false
 
 consumer:
   # number of seconds after which, if a client hasn't contacted the Kafka cluster,

--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -60,6 +60,11 @@ producer:
   # if greater than zero, the number of seconds between automatic message
   # deliveries. Only used for async_producer
   delivery_interval: 0
+  # Set this to true to cache the sync producer between publish calls.
+  # This can speed up subsequent messages by around 30%, but it does mean
+  # that you need to manually call sync_producer_shutdown before exiting,
+  # similar to async_producer_shutdown.
+  cache_sync_producer: false
 
 consumer:
   # number of seconds after which, if a client hasn't contacted the Kafka cluster,

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -55,20 +55,10 @@ module Phobos
 
     def configure(configuration)
       @config = fetch_configuration(configuration)
-      config_define_methods
+      @config.class.send(:define_method, :producer_hash) { Phobos.config.producer&.to_hash }
+      @config.class.send(:define_method, :consumer_hash) { Phobos.config.consumer&.to_hash }
       @config.listeners ||= []
       configure_logger
-    end
-
-    def config_define_methods # rubocop:disable Metrics/AbcSize
-      @config.class.send(:define_method, :cache_sync_producer) do
-        hash = Phobos.config.producer&.to_hash
-        hash[:cache_sync_producer]
-      end
-      @config.class.send(:define_method, :producer_hash) do
-        Phobos.config.producer&.to_hash&.except(:cache_sync_producer)
-      end
-      @config.class.send(:define_method, :consumer_hash) { Phobos.config.consumer&.to_hash }
     end
 
     def add_listeners(configuration)

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -31,6 +31,8 @@ require 'phobos/executor'
 
 Thread.abort_on_exception = true
 
+Logging.init :debug, :info, :warn, :error, :fatal
+
 # Monkey patch to fix this issue: https://github.com/zendesk/ruby-kafka/pull/732
 module Logging
   # :nodoc:

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -71,7 +71,9 @@ module Phobos
         def create_sync_producer
           client = kafka_client || configure_kafka_client(Phobos.create_kafka_client)
           sync_producer = client.producer(regular_configs)
-          producer_store[:sync_producer] = sync_producer if Phobos.config.persistent_connections
+          if Phobos.config.producer_hash[:persistent_connections]
+            producer_store[:sync_producer] = sync_producer
+          end
           sync_producer
         end
 
@@ -94,7 +96,7 @@ module Phobos
           produce_messages(producer, messages)
           producer.deliver_messages
         ensure
-          producer&.shutdown unless Phobos.config.persistent_connections
+          producer&.shutdown unless Phobos.config.producer_hash[:persistent_connections]
         end
 
         def create_async_producer

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe 'CHANGELOG.md' do
   it 'the latest version is described in changelog' do
     changelog = File.read('CHANGELOG.md')
-    latest_version = changelog.match(/^## \[(\d+\.\d+\.\d+)\]/)
+    latest_version = changelog.match(/^## \[(\d+\.\d+\.\d+(-beta\d+)?)\]/)
     expect(latest_version).to_not be_nil
     expect(latest_version[1]).to eq(Phobos::VERSION)
   end

--- a/spec/lib/phobos/producer_spec.rb
+++ b/spec/lib/phobos/producer_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Phobos::Producer do
 
       context 'with cached producer' do
         it 'publishes and delivers a list of messages twice' do
-          allow(Phobos.config).to receive(:cache_sync_producer).and_return(true)
+          allow(Phobos.config).to receive(:persistent_connections).and_return(true)
           allow(producer).to receive(:shutdown)
           expect(kafka_client)
             .to receive(:producer)
@@ -325,7 +325,7 @@ RSpec.describe Phobos::Producer do
     let(:kafka_client) { double('Kafka::Client', producer: producer, close: true) }
 
     it 'calls shutdown in the configured client and cleans up producer' do
-      allow(Phobos.config).to receive(:cache_sync_producer).and_return(true)
+      allow(Phobos.config).to receive(:persistent_connections).and_return(true)
       expect(producer).to receive(:shutdown)
 
       Thread.new do

--- a/spec/lib/phobos/producer_spec.rb
+++ b/spec/lib/phobos/producer_spec.rb
@@ -274,9 +274,10 @@ RSpec.describe Phobos::Producer do
 
     describe 'without a kafka_client configured' do
       it 'creates a new client and an async_producer bound to the current thread' do
+        config = Phobos.config.producer_hash.reject { |k, _| %i(persistent_connections).include?(k) }
         expect(kafka_client)
           .to receive(:async_producer)
-          .with(Phobos.config.producer_hash)
+          .with(config)
           .and_return(:async1, :async2)
 
         expect(Phobos)

--- a/spec/lib/phobos/producer_spec.rb
+++ b/spec/lib/phobos/producer_spec.rb
@@ -76,7 +76,9 @@ RSpec.describe Phobos::Producer do
 
       context 'with cached producer' do
         it 'publishes and delivers a list of messages twice' do
-          allow(Phobos.config).to receive(:persistent_connections).and_return(true)
+          original_hash = Phobos.config.producer_hash
+          allow(Phobos.config).to receive(:producer_hash)
+                                    .and_return(original_hash.merge(:persistent_connections => true))
           allow(producer).to receive(:shutdown)
           expect(kafka_client)
             .to receive(:producer)
@@ -169,7 +171,11 @@ RSpec.describe Phobos::Producer do
       end
 
       describe 'with a delivery interval set' do
-        let(:config_hash) { Phobos.config.producer_hash.merge(delivery_interval: 10) }
+        let(:config_hash) do
+          hash = Phobos.config.producer_hash.merge(delivery_threshold: 10)
+          hash.delete(:persistent_connections)
+          hash
+        end
 
         before do
           allow_any_instance_of(Phobos::Producer::ClassMethods::PublicAPI)
@@ -191,7 +197,11 @@ RSpec.describe Phobos::Producer do
       end
 
       describe 'with a delivery threshold set' do
-        let(:config_hash) { Phobos.config.producer_hash.merge(delivery_threshold: 10) }
+        let(:config_hash) do
+          hash = Phobos.config.producer_hash.merge(delivery_threshold: 10)
+          hash.delete(:persistent_connections)
+          hash
+        end
 
         before do
           allow_any_instance_of(Phobos::Producer::ClassMethods::PublicAPI)
@@ -325,7 +335,9 @@ RSpec.describe Phobos::Producer do
     let(:kafka_client) { double('Kafka::Client', producer: producer, close: true) }
 
     it 'calls shutdown in the configured client and cleans up producer' do
-      allow(Phobos.config).to receive(:persistent_connections).and_return(true)
+      original_hash = Phobos.config.producer_hash
+      allow(Phobos.config).to receive(:producer_hash)
+                                .and_return(original_hash.merge(:persistent_connections => true))
       expect(producer).to receive(:shutdown)
 
       Thread.new do


### PR DESCRIPTION
In investigating the speed of our producers sending synchronously, the `shutdown` and producer creation calls turned out to have increased our Kafka connection time by around 30%. I tried this in a monkey patch and our speed increased by that amount.

This adds a new setting, `cache_sync_producer`, which makes sync producers act like async ones. It requires a `sync_producer_shutdown` call, but also caches the sync producer between calls, so it just reuses the same one and isn't constantly shutting it down and creating new ones.