### PR TITLE
Add support for producing and consuming messages with headers

### DIFF
--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -16,7 +16,8 @@ module Phobos
           key: message.key,
           partition: message.partition,
           offset: message.offset,
-          retry_count: 0
+          retry_count: 0,
+          headers: message.headers
         )
       end
 

--- a/lib/phobos/batch_message.rb
+++ b/lib/phobos/batch_message.rb
@@ -2,17 +2,18 @@
 
 module Phobos
   class BatchMessage
-    attr_accessor :key, :partition, :offset, :payload
+    attr_accessor :key, :partition, :offset, :payload, :headers
 
-    def initialize(key:, partition:, offset:, payload:)
+    def initialize(key:, partition:, offset:, payload:, headers:)
       @key = key
       @partition = partition
       @offset = offset
       @payload = payload
+      @headers = headers
     end
 
     def ==(other)
-      [:key, :partition, :offset, :payload].all? do |s|
+      [:key, :partition, :offset, :payload, :headers].all? do |s|
         public_send(s) == other.public_send(s)
       end
     end

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -15,18 +15,18 @@ module Phobos
         @host_obj = host_obj
       end
 
-      def publish(topic, payload, key = nil, partition_key = nil)
-        class_producer.publish(topic, payload, key, partition_key)
+      def publish(topic, payload, key = nil, partition_key = nil, headers = nil)
+        class_producer.publish(topic, payload, key, partition_key, headers)
       end
 
-      def async_publish(topic, payload, key = nil, partition_key = nil)
-        class_producer.async_publish(topic, payload, key, partition_key)
+      def async_publish(topic, payload, key = nil, partition_key = nil, headers = nil)
+        class_producer.async_publish(topic, payload, key, partition_key, headers)
       end
 
-      # @param messages [Array(Hash(:topic, :payload, :key))]
+      # @param messages [Array(Hash(:topic, :payload, :key, :headers))]
       #        e.g.: [
-      #          { topic: 'A', payload: 'message-1', key: '1' },
-      #          { topic: 'B', payload: 'message-2', key: '2' }
+      #          { topic: 'A', payload: 'message-1', key: '1', headers: { foo: 'bar' } },
+      #          { topic: 'B', payload: 'message-2', key: '2', headers: { foo: 'bar' } }
       #        ]
       #
       def publish_list(messages)
@@ -86,9 +86,9 @@ module Phobos
           producer_store[:sync_producer] = nil
         end
 
-        def publish(topic, payload, key = nil, partition_key = nil)
+        def publish(topic, payload, key = nil, partition_key = nil, headers = nil)
           publish_list([{ topic: topic, payload: payload, key: key,
-                          partition_key: partition_key }])
+                          partition_key: partition_key, headers: headers }])
         end
 
         def publish_list(messages)
@@ -109,9 +109,9 @@ module Phobos
           producer_store[:async_producer]
         end
 
-        def async_publish(topic, payload, key = nil, partition_key = nil)
+        def async_publish(topic, payload, key = nil, partition_key = nil, headers = nil)
           async_publish_list([{ topic: topic, payload: payload, key: key,
-                                partition_key: partition_key }])
+                                partition_key: partition_key, headers: headers }])
         end
 
         def async_publish_list(messages)
@@ -144,6 +144,7 @@ module Phobos
             partition_key = message[:partition_key] || message[:key]
             producer.produce(message[:payload], topic: message[:topic],
                                                 key: message[:key],
+                                                headers: message[:headers],
                                                 partition_key: partition_key)
           end
         end

--- a/spec/lib/phobos/actions/process_batch_inline_spec.rb
+++ b/spec/lib/phobos/actions/process_batch_inline_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 RSpec.describe Phobos::Actions::ProcessBatchInline do
   class TestBatchHandler
     include Phobos::BatchHandler
+
     def consume_batch(payloads, metadata)
       Phobos.logger.info { Hash(payloads: payloads).merge(metadata) }
     end
@@ -14,14 +15,14 @@ RSpec.describe Phobos::Actions::ProcessBatchInline do
   let(:topic) { 'test-topic' }
   let(:message1) do
     Kafka::FetchedMessage.new(
-      message: Kafka::Protocol::Message.new(value: 'value-1', key: 'key-1', offset: 2),
+      message: Kafka::Protocol::Record.new(value: 'value-1', key: 'key-1', offset: 2),
       topic: topic,
       partition: 1
     )
   end
   let(:message2) do
     Kafka::FetchedMessage.new(
-      message: Kafka::Protocol::Message.new(value: 'value-2', key: 'key-2', offset: 4),
+      message: Kafka::Protocol::Record.new(value: 'value-2', key: 'key-2', offset: 4),
       topic: topic,
       partition: 3
     )
@@ -63,7 +64,8 @@ RSpec.describe Phobos::Actions::ProcessBatchInline do
         key: message.key,
         partition: message.partition,
         offset: message.offset,
-        payload: message.value
+        payload: message.value,
+        headers: message.headers
       )
     end
 

--- a/spec/lib/phobos/actions/process_message_spec.rb
+++ b/spec/lib/phobos/actions/process_message_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe Phobos::Actions::ProcessMessage do
 
   let(:payload) { 'message-1234' }
   let(:topic) { 'test-topic' }
+  let(:headers) { { header_1: '1', header_2: '2' } }
   let(:message) do
     Kafka::FetchedMessage.new(
-      message: Kafka::Protocol::Message.new(value: payload, key: 'key-1', offset: 2),
+      message: Kafka::Protocol::Record.new(value: payload, key: 'key-1', offset: 2, headers: headers),
       topic: topic,
       partition: 1
     )
@@ -59,6 +60,11 @@ RSpec.describe Phobos::Actions::ProcessMessage do
     expect_any_instance_of(TestHandler).to receive(:before_consume).with(payload, subject.metadata).once.and_call_original
     expect_any_instance_of(TestHandler).to receive(:consume).with(payload, subject.metadata).once.and_call_original
 
+    subject.execute
+  end
+
+  it "merges the message's headers into the metadata that's passed to the handler" do
+    expect_any_instance_of(TestHandler).to receive(:consume).with(payload, hash_including(headers: headers)).once.and_call_original
     subject.execute
   end
 

--- a/spec/lib/phobos/producer_spec.rb
+++ b/spec/lib/phobos/producer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Phobos::Producer do
 
       expect(TestProducer1.producer)
         .to receive(:publish_list)
-        .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: nil }])
+        .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: nil, headers: nil }])
 
       subject.producer.publish('topic', 'message', 'key')
     end
@@ -32,10 +32,10 @@ RSpec.describe Phobos::Producer do
 
       expect(TestProducer1.producer)
         .to receive(:async_publish_list)
-        .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: 'partition_key' }])
+        .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: 'partition_key', headers: { foo: 'bar' } }])
 
       TestProducer1.producer.create_async_producer
-      subject.producer.async_publish('topic', 'message', 'key', 'partition_key')
+      subject.producer.async_publish('topic', 'message', 'key', 'partition_key', foo: 'bar')
     end
   end
 
@@ -58,11 +58,11 @@ RSpec.describe Phobos::Producer do
 
           expect(producer)
             .to receive(:produce)
-            .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1')
+            .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1', headers: nil)
 
           expect(producer)
             .to receive(:produce)
-            .with('message-2', topic: 'topic-2', key: 'key-2', partition_key: 'key-2')
+            .with('message-2', topic: 'topic-2', key: 'key-2', partition_key: 'key-2', headers: { foo: 'bar' })
 
           expect(producer).to receive(:deliver_messages)
           expect(producer).to receive(:shutdown)
@@ -70,7 +70,7 @@ RSpec.describe Phobos::Producer do
 
           subject.producer.publish_list([
                                           { payload: 'message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1' },
-                                          { payload: 'message-2', topic: 'topic-2', key: 'key-2' }
+                                          { payload: 'message-2', topic: 'topic-2', key: 'key-2', headers: { foo: 'bar' } }
                                         ])
         end
       end
@@ -91,15 +91,15 @@ RSpec.describe Phobos::Producer do
 
           expect(producer)
             .to receive(:produce)
-            .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1')
+            .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1', headers: nil)
 
           expect(producer)
             .to receive(:produce)
-            .with('message-2', topic: 'topic-2', key: 'key-2', partition_key: 'key-2')
+            .with('message-2', topic: 'topic-2', key: 'key-2', partition_key: 'key-2', headers: { foo: 'bar' })
 
           expect(producer)
             .to receive(:produce)
-            .with('message-3', topic: 'topic-3', key: 'key-3', partition_key: 'part-key-3')
+            .with('message-3', topic: 'topic-3', key: 'key-3', partition_key: 'part-key-3', headers: nil)
 
           expect(producer).to receive(:deliver_messages).twice
           expect(producer).to_not have_received(:shutdown)
@@ -107,7 +107,7 @@ RSpec.describe Phobos::Producer do
 
           subject.producer.publish_list([
                                           { payload: 'message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1' },
-                                          { payload: 'message-2', topic: 'topic-2', key: 'key-2' }
+                                          { payload: 'message-2', topic: 'topic-2', key: 'key-2', headers: { foo: 'bar' } }
                                         ])
           subject.producer.publish_list([
                                           { payload: 'message-3', topic: 'topic-3', key: 'key-3', partition_key: 'part-key-3' }
@@ -132,18 +132,18 @@ RSpec.describe Phobos::Producer do
 
         expect(producer)
           .to receive(:produce)
-          .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1')
+          .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1', headers: { foo: 'bar' })
 
         expect(producer)
           .to receive(:produce)
-          .with('message-2', topic: 'topic-2', key: 'key-2', partition_key: 'key-2')
+          .with('message-2', topic: 'topic-2', key: 'key-2', partition_key: 'key-2', headers: nil)
 
         expect(producer).to receive(:deliver_messages)
         expect(producer).to receive(:shutdown)
         expect(kafka_client).to_not receive(:close)
 
         subject.producer.publish_list([
-                                        { payload: 'message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1' },
+                                        { payload: 'message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1', headers: { foo: 'bar' } },
                                         { payload: 'message-2', topic: 'topic-2', key: 'key-2' }
                                       ])
       end
@@ -164,11 +164,11 @@ RSpec.describe Phobos::Producer do
 
         expect(producer)
           .to receive(:produce)
-          .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'key-1')
+          .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'key-1', headers: { foo: 'bar' })
 
         expect(producer)
           .to receive(:produce)
-          .with('message-2', topic: 'topic-2', key: 'key-2', partition_key: 'key-2')
+          .with('message-2', topic: 'topic-2', key: 'key-2', partition_key: 'key-2', headers: nil)
 
         expect(producer).to_not receive(:close)
       end
@@ -191,7 +191,7 @@ RSpec.describe Phobos::Producer do
             TestProducer1.producer.configure_kafka_client(kafka_client)
 
             subject.producer.async_publish_list([
-                                                  { payload: 'message-1', topic: 'topic-1', key: 'key-1' },
+                                                  { payload: 'message-1', topic: 'topic-1', key: 'key-1', headers: { foo: 'bar' } },
                                                   { payload: 'message-2', topic: 'topic-2', key: 'key-2' }
                                                 ])
           end.join
@@ -216,7 +216,7 @@ RSpec.describe Phobos::Producer do
             TestProducer1.producer.configure_kafka_client(kafka_client)
 
             subject.producer.async_publish_list([
-                                                  { payload: 'message-1', topic: 'topic-1', key: 'key-1' },
+                                                  { payload: 'message-1', topic: 'topic-1', key: 'key-1', headers: { foo: 'bar' } },
                                                   { payload: 'message-2', topic: 'topic-2', key: 'key-2' }
                                                 ])
           end.join
@@ -234,7 +234,7 @@ RSpec.describe Phobos::Producer do
             TestProducer1.producer.configure_kafka_client(kafka_client)
 
             subject.producer.async_publish_list([
-                                                  { payload: 'message-1', topic: 'topic-1', key: 'key-1' },
+                                                  { payload: 'message-1', topic: 'topic-1', key: 'key-1', headers: { foo: 'bar' } },
                                                   { payload: 'message-2', topic: 'topic-2', key: 'key-2' }
                                                 ])
           end.join

--- a/spec/lib/phobos/test/helper_spec.rb
+++ b/spec/lib/phobos/test/helper_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Phobos::Test::Helper do
 
   let(:payload) { 'foo' }
   let(:metadata) { Hash(foo: 'bar') }
-  let(:listener_metadata) { Hash(key: nil, partition: 0, offset: 13, retry_count: 0) }
+  let(:listener_metadata) { Hash(key: nil, partition: 0, offset: 13, retry_count: 0, headers: {}) }
   let(:topic) { Phobos::Test::Helper::Topic }
   let(:group_id) { Phobos::Test::Helper::Group }
 


### PR DESCRIPTION
This PR adds support for producing and consuming messages with headers.

### Producing

When producing a single message, the `publish` method signature is as follows:

```ruby
def publish(topic, payload, key = nil, partition_key = nil, headers = nil)
end
```

The difference between `key` and `partition_key` here is not clear to me and I appreciate that adding yet another positional argument to the method is not ideal, but I think changing this to use keyword arguments would be outside of the scope of this PR. 

The downside of this implementation is that if users want to specify message headers but do not care about `partition_key`, they will still have to call `publish` with all the arguments, using a value of `nil` for the `partition_key` attribute.

When publishing a batch of messages the API works better, since each message is represented by a `Hash`. I simply added one more key `headers` to the hash. 

### Consuming

~To avoid introducing breaking changes to the handler API, I decided to add a new listener configuration option to the `phobos.yml` file, called `consume_message_headers`, which defaults to `false`.~

~If `consume_message_headers` is set to to `true`, handlers need to implement the `consume` method with an additional argument for the headers:~

~If the `consume_message_headers` option is set to `false` or not specified at all, nothing changes and the version of `consume` with two arguments will be used. This guarantee compatibility for existent handlers.~

Headers will be merged into the `metadata` hash, under a `headers` key.

When consuming a batch of messages, the headers will also be present in instances of `BatchMessage`. This was actually easy to implement since in runtime `BatchMessage` simply wraps instances of `Kafka::Protocol::Record`, which will always contain the headers anyway (feature already supported by `ruby-kafka`).

I ~updated the `phobos.yml.example` file and also~ added some new stuff to the `README`.

Let me know what you think. Thanks for creating Phobos! 