### PR TITLE
Trigger heartbeat if necessary after each message in a batch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
+- Automatically heartbeat after every message if necessary in batch 
+  mode.
 
 ## [1.8.2-beta2] - 2019-06-21
 - Added the `persistent_connections` setting and the corresponding

--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -109,11 +109,8 @@ listeners:
     # Possible values: [`message`, `batch` (default)]
     #  - `message` will yield individual messages from Ruby Kafka using `each_message` and will commit/heartbeat at every consumed message.
     #     This is overall a bit slower than using batch, but easier to configure.
-    #  - `batch` will yield batches from Ruby Kafka using `each_batch`, and commit/heartbeat at every consumed batch.
-    #     Due to implementation in Ruby Kafka, it should be noted that when configuring large batch sizes in combination with taking long time to consume messages,
-    #     your consumers might get kicked from the Kafka cluster for not sending a heartbeat within the expected interval.
-    #     Take this into consideration when determining your configuration. You can send heartbeats manually while
-    #     processing your messages if necessary.
+    #  - `batch` will yield batches from Ruby Kafka using `each_batch`, and commit at every consumed batch. It will
+    #     still heartbeat after every message if necessary (using the heartbeat_interval, below).
     #   - `inline_batch` also uses `each_batch`, but will pass the entire batch to your handler instead
     #     of one message at a time. To use this method, you should include Phobos::BatchHandler
     #     instead of Phobos::Handler so that you can make use of the `consume_batch` etc. methods.

--- a/lib/phobos/actions/process_batch.rb
+++ b/lib/phobos/actions/process_batch.rb
@@ -26,6 +26,7 @@ module Phobos
               message: message,
               listener_metadata: @listener_metadata
             ).execute
+            @listener.consumer.trigger_heartbeat
           end
         end
       end

--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -10,7 +10,7 @@ module Phobos
     DELIVERY_OPTS = %w[batch message inline_batch].freeze
 
     attr_reader :group_id, :topic, :id
-    attr_reader :handler_class, :encoding
+    attr_reader :handler_class, :encoding, :consumer
 
     # rubocop:disable Metrics/MethodLength
     def initialize(handler:, group_id:, topic:, min_bytes: nil, max_wait_time: nil,

--- a/spec/lib/phobos/actions/process_batch_spec.rb
+++ b/spec/lib/phobos/actions/process_batch_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe Phobos::Actions::ProcessBatch do
       listener_metadata: listener_metadata
     ).once.ordered.and_call_original
 
+    expect(listener.consumer).to receive(:trigger_heartbeat).twice
+
     subject.execute
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'phobos'
 require 'pry-byebug'
 require 'timecop'
 require 'phobos/test'
+require 'active_support/core_ext'
 
 Dir.entries('./spec/support').select { |f| f =~ /\.rb$/ }.each do |f|
   load "./spec/support/#{f}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ require 'pry-byebug'
 require 'timecop'
 require 'phobos/test'
 require 'active_support/core_ext'
+require 'active_support/json'
 
 Dir.entries('./spec/support').select { |f| f =~ /\.rb$/ }.each do |f|
   load "./spec/support/#{f}"


### PR DESCRIPTION
We have run into multiple issues where processing a batch that takes too long causes the consumer to be kicked out of the group. I know this is called out in the sample config, but I don't really see a point in us *not* heartbeating automatically after every message in batch (as opposed to inline_batch) mode. The configured heartbeat interval ensures that we're not sending heartbeats unnecessarily, and it ensures that as long as we can get through individual messages fast enough, we should be good forever.

@klippx we can aim for 1.9 with this, no?