### PR TITLE
Use keyword arguments when publshing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,24 +281,26 @@ The producer module doesn't pollute your classes with a thousand methods, it inc
 
 ```ruby
 my = MyProducer.new
-my.producer.publish('topic', 'message-payload', 'partition and message key')
+my.producer.publish(topic: 'topic', payload: 'message-payload', key: 'partition and message key')
 
 # The code above has the same effect of this code:
-MyProducer.producer.publish('topic', 'message-payload', 'partition and message key')
+MyProducer.producer.publish(topic: 'topic', payload: 'message-payload', key: 'partition and message key')
 ```
 
 The signature for the `publish` method is as follows:
 
 ```ruby
-def publish(topic, payload, key = nil, partition_key = nil, headers = nil)
+def publish(topic: topic, payload: payload, key: nil, partition_key: nil, headers: nil)
 ```
 
-To produce messages with headers, 5 arguments will have to be passed to `publish`:
+When publishing a message with headers, the `headers` argument must be a hash:
 
 ```ruby
 my = MyProducer.new
-my.producer.publish('topic', 'message-payload', 'partition and message key', nil, { header_1: 'value 1' })
+my.producer.publish(topic: 'topic', payload: 'message-payload', key: 'partition and message key', headers: { header_1: 'value 1' })
 ```
+
+Older versions of Phobos provided a `publish` method that accepted positional arguments. This version is still supported but it's soon to be deprecated in favour of the keyword arguments version.
 
 It is also possible to publish several messages at once:
 
@@ -328,7 +330,7 @@ class MyHandler
   PUBLISH_TO = 'topic2'
 
   def consume(payload, metadata)
-    producer.async_publish(PUBLISH_TO, {key: 'value'}.to_json)
+    producer.async_publish(topic: PUBLISH_TO, payload: {key: 'value'}.to_json)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ my = MyProducer.new
 my.producer.publish(topic: 'topic', payload: 'message-payload', key: 'partition and message key', headers: { header_1: 'value 1' })
 ```
 
-Older versions of Phobos provided a `publish` method that accepted positional arguments. This version is still supported but it's soon to be deprecated in favour of the keyword arguments version.
+Older versions of Phobos provided a `publish` method that accepted positional arguments. That version is still supported but it's soon to be deprecated in favour of the keyword arguments version.
 
 It is also possible to publish several messages at once:
 

--- a/examples/publishing_messages_without_consumer.rb
+++ b/examples/publishing_messages_without_consumer.rb
@@ -45,7 +45,7 @@ Thread.new do
         #
         MyProducer
           .producer
-          .async_publish(TOPIC, payload, key)
+          .async_publish(topic: TOPIC, payload: payload, key: key)
 
         puts "produced #{key}, total: #{total}"
 

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -78,7 +78,8 @@ module Phobos
     end
 
     def deprecate(message)
-      warn "DEPRECATION WARNING: #{message} #{Kernel.caller.first}"
+      location = caller.find { |line| line !~ %r{/phobos/} }
+      warn "DEPRECATION WARNING: #{message}: #{location}"
     end
 
     # :nodoc:

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -44,8 +44,8 @@ module Phobos
 
           if @listener.handler_class.respond_to?(:around_consume)
             # around_consume class method implementation
-            Phobos.deprecate('around_consume has been moved to instance method, '\
-              'please update your consumer. This will not be backwards compatible in the future.')
+            Phobos.deprecate('around_consume has been moved to instance method, please update '\
+                             'your consumer. This will not be backwards compatible in the future.')
             @listener.handler_class.around_consume(preprocessed_payload, @metadata, &consume_block)
           else
             # around_consume instance method implementation
@@ -57,8 +57,9 @@ module Phobos
       def before_consume(handler, payload)
         handler.before_consume(payload, @metadata)
       rescue ArgumentError
-        Phobos.deprecate('before_consume now expects metadata as second argument, '\
-          'please update your consumer. This will not be backwards compatible in the future.')
+        Phobos.deprecate('before_consume now expects metadata as second argument, please update '\
+                         'your consumer. This will not be backwards compatible in the future.')
+
         handler.before_consume(payload)
       end
     end

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -11,16 +11,26 @@ module Phobos
     end
 
     class PublicAPI
+      MissingRequiredArgumentsError = Class.new(StandardError) do
+        def initialize
+          super('You need to provide a topic name and a payload')
+        end
+      end
+
       def initialize(host_obj)
         @host_obj = host_obj
       end
 
-      def publish(topic, payload, key = nil, partition_key = nil, headers = nil)
-        class_producer.publish(topic, payload, key, partition_key, headers)
+      def publish(*args, **kwargs)
+        args = normalize_arguments(*args, **kwargs)
+
+        class_producer.publish(**args)
       end
 
-      def async_publish(topic, payload, key = nil, partition_key = nil, headers = nil)
-        class_producer.async_publish(topic, payload, key, partition_key, headers)
+      def async_publish(*args, **kwargs)
+        args = normalize_arguments(*args, **kwargs)
+
+        class_producer.async_publish(**args)
       end
 
       # @param messages [Array(Hash(:topic, :payload, :key, :headers))]
@@ -42,6 +52,30 @@ module Phobos
       def class_producer
         @host_obj.class.producer
       end
+
+      # rubocop:disable Metrics/ParameterLists
+      def normalize_arguments(p_topic = nil, p_payload = nil, p_key = nil,
+                              p_partition_key = nil, p_headers = {},
+                              **kwargs)
+        {}.tap do |args|
+          {
+            topic: p_topic,
+            payload: p_payload,
+            key: p_key,
+            partition_key: p_partition_key,
+            headers: p_headers
+          }.each { |k, v| args[k] = kwargs[k] || v }
+
+          raise MissingRequiredArgumentsError if [:topic, :payload].any? { |k| args[k].nil? }
+
+          kwargs.each do |k, v|
+            next if args.key?(k)
+
+            args[:headers][k] = v
+          end
+        end
+      end
+      # rubocop:enable Metrics/ParameterLists
     end
 
     module ClassMethods
@@ -86,7 +120,7 @@ module Phobos
           producer_store[:sync_producer] = nil
         end
 
-        def publish(topic, payload, key = nil, partition_key = nil, headers = nil)
+        def publish(topic:, payload:, key: nil, partition_key: nil, headers: nil)
           publish_list([{ topic: topic, payload: payload, key: key,
                           partition_key: partition_key, headers: headers }])
         end
@@ -109,7 +143,7 @@ module Phobos
           producer_store[:async_producer]
         end
 
-        def async_publish(topic, payload, key = nil, partition_key = nil, headers = nil)
+        def async_publish(topic:, payload:, key: nil, partition_key: nil, headers: nil)
           async_publish_list([{ topic: topic, payload: payload, key: key,
                                 partition_key: partition_key, headers: headers }])
         end

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -22,14 +22,16 @@ module Phobos
       end
 
       def publish(*args, **kwargs)
-        args = normalize_arguments(*args, **kwargs)
+        Phobos.deprecate(deprecate_positional_args_message('publish')) if kwargs.empty?
 
+        args = normalize_arguments(*args, **kwargs)
         class_producer.publish(**args)
       end
 
       def async_publish(*args, **kwargs)
-        args = normalize_arguments(*args, **kwargs)
+        Phobos.deprecate(deprecate_positional_args_message('async_publish')) if kwargs.empty?
 
+        args = normalize_arguments(*args, **kwargs)
         class_producer.async_publish(**args)
       end
 
@@ -76,6 +78,12 @@ module Phobos
         end
       end
       # rubocop:enable Metrics/ParameterLists
+
+      def deprecate_positional_args_message(method_name)
+        "The `#{method_name}` method should now receive keyword arguments " \
+          'rather than positional ones. Please update your publishers. This will ' \
+          'not be backwards compatible in the future.'
+      end
     end
 
     module ClassMethods

--- a/spec/lib/phobos/executor_spec.rb
+++ b/spec/lib/phobos/executor_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Phobos::Executor do
       .and_raise(Exception, 'not retryable error')
 
     # publish event to both consumers
-    producer.publish(topics.first, 'message-1')
-    producer.publish(topics.last, 'message-1')
+    producer.publish(topic: topics.first, payload: 'message-1')
+    producer.publish(topic: topics.last, payload: 'message-1')
 
     wait_for_event('executor.retry_listener_error', amount_gte: 1)
 
@@ -153,7 +153,7 @@ RSpec.describe Phobos::Executor do
         .to receive(:consume)
         .and_raise(Exception, 'not retryable error')
 
-      producer.publish(topics.first, 'message-1')
+      producer.publish(topic: topics.first, payload: 'message-1')
       wait_for_event('executor.retry_listener_error', amount: 1)
       wait_for_event('listener.start', amount_gte: 1)
 
@@ -178,7 +178,7 @@ RSpec.describe Phobos::Executor do
           .to receive(:consume)
           .and_raise(Exception, 'not retryable error')
 
-        producer.publish(topics.last, 'message-1')
+        producer.publish(topic: topics.last, payload: 'message-1')
         wait_for_event('executor.retry_listener_error', amount: 1)
         wait_for_event('listener.start', amount_gte: 1)
 

--- a/spec/lib/phobos/listener_spec.rb
+++ b/spec/lib/phobos/listener_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Phobos::Listener do
           .with('message-1', hash_including(group_id: group_id, topic: topic, listener_id: listener.id))
           .once { Timecop.freeze(now + 0.1) }
 
-      producer.publish(topic, 'message-1')
+      producer.publish(topic: topic, payload: 'message-1')
 
       wait_for_event('listener.process_message')
       event = events_for('listener.process_message').first
@@ -115,7 +115,7 @@ RSpec.describe Phobos::Listener do
         )
         .and_call_original
 
-      producer.async_publish(topic, 'message-1')
+      producer.async_publish(topic: topic, payload: 'message-1')
       wait_for_event('listener.process_batch')
 
       listener.stop
@@ -140,7 +140,7 @@ RSpec.describe Phobos::Listener do
           )
           .and_call_original
 
-        producer.async_publish(topic, 'message-1')
+        producer.async_publish(topic: topic, payload: 'message-1')
         wait_for_event('listener.process_batch_inline')
 
         listener.stop
@@ -172,7 +172,7 @@ RSpec.describe Phobos::Listener do
           .with('message-1', hash_including(group_id: group_id, topic: topic, listener_id: listener.id))
           .once { Timecop.freeze(now + 0.1) }
 
-      producer.publish(topic, 'message-1')
+      producer.publish(topic: topic, payload: 'message-1')
 
       wait_for_event('listener.process_message')
       event = events_for('listener.process_message').first
@@ -196,7 +196,7 @@ RSpec.describe Phobos::Listener do
         )
         .and_call_original
 
-      producer.async_publish(topic, 'message-1')
+      producer.async_publish(topic: topic, payload: 'message-1')
       wait_for_event('listener.process_message')
 
       listener.stop
@@ -346,7 +346,7 @@ RSpec.describe Phobos::Listener do
       .to receive(:consume)
       .with('message-1', hash_including(retry_count: kind_of(Numeric)))
 
-    producer.publish(topic, 'message-1')
+    producer.publish(topic: topic, payload: 'message-1')
     wait_for_event('listener.process_batch')
 
     listener.stop
@@ -366,7 +366,7 @@ RSpec.describe Phobos::Listener do
       .to receive(:consume)
       .and_raise('handler exception')
 
-    producer.publish(topic, 'message-1')
+    producer.publish(topic: topic, payload: 'message-1')
     wait_for_event('listener.retry_handler_error', amount: 1, ignore_errors: false)
 
     listener.stop
@@ -480,7 +480,7 @@ RSpec.describe Phobos::Listener do
     subscribe_to(*LISTENER_EVENTS) { thread }
     wait_for_event('listener.start')
 
-    producer.publish(topic, 'message-1')
+    producer.publish(topic: topic, payload: 'message-1')
     wait_for_event('listener.process_message')
 
     listener.stop

--- a/spec/lib/phobos/producer_spec.rb
+++ b/spec/lib/phobos/producer_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe Phobos::Producer do
       subject.producer.publish('topic', 'message', 'key')
     end
 
+    it 'logs a deprecation message when called with positional arguments' do
+      expect(Phobos).to receive(:deprecate).with(
+        /The `publish` method should now receive keyword arguments rather than positional ones/
+      )
+
+      subject.producer.publish('topic', 'message', 'key')
+    end
+
     it 'publishes a single message using "publish_list" when called with keyword arguments' do
       expect(TestProducer1.producer)
         .to receive(:publish_list)
@@ -47,6 +55,14 @@ RSpec.describe Phobos::Producer do
 
       TestProducer1.producer.create_async_producer
       subject.producer.async_publish('topic', 'message', 'key', nil, foo: 'bar', fizz: 'buzz')
+    end
+
+    it 'logs a deprecation message when called with positional arguments' do
+      expect(Phobos).to receive(:deprecate).with(
+        /The `async_publish` method should now receive keyword arguments rather than positional ones/
+      )
+
+      subject.producer.async_publish('topic', 'message', 'key')
     end
 
     it 'publishes a single message using "async_publish" when called with keyword arguments' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,9 @@ require 'phobos'
 require 'pry-byebug'
 require 'timecop'
 require 'phobos/test'
-require 'active_support/core_ext'
 require 'active_support/json'
+require 'active_support'
+require 'active_support/core_ext'
 
 Dir.entries('./spec/support').select { |f| f =~ /\.rb$/ }.each do |f|
   load "./spec/support/#{f}"


### PR DESCRIPTION
Hello 👋 

This PR changes the signature of the `publish` and `publish_async` methods to use keyword arguments instead of positional arguments.

Currently those methods accept 5 arguments, which makes it harder to know in which order those arguments should be specified. The use of keyword arguments makes it easier to use Phobos when producing messages.