### PR TITLE
#84: Deprecate before_consume and add ability to yield payloads to ar…

### DIFF
--- a/lib/phobos/batch_handler.rb
+++ b/lib/phobos/batch_handler.rb
@@ -6,16 +6,12 @@ module Phobos
       base.extend(ClassMethods)
     end
 
-    def before_consume_batch(payloads, _metadata)
-      payloads
-    end
-
     def consume_batch(_payloads, _metadata)
       raise NotImplementedError
     end
 
-    def around_consume_batch(_payloads, _metadata)
-      yield
+    def around_consume_batch(payloads, metadata)
+      yield payloads, metadata
     end
 
     module ClassMethods

--- a/lib/phobos/handler.rb
+++ b/lib/phobos/handler.rb
@@ -6,16 +6,12 @@ module Phobos
       base.extend(ClassMethods)
     end
 
-    def before_consume(payload, _metadata)
-      payload
-    end
-
     def consume(_payload, _metadata)
       raise NotImplementedError
     end
 
-    def around_consume(_payload, _metadata)
-      yield
+    def around_consume(payload, metadata)
+      yield payload, metadata
     end
 
     module ClassMethods

--- a/spec/lib/phobos/batch_handler_spec.rb
+++ b/spec/lib/phobos/batch_handler_spec.rb
@@ -18,11 +18,7 @@ RSpec.describe Phobos::BatchHandler do
 
   it 'includes default "#around_consume_batch"' do
     expect { |block| TestIncludeBatchHandler.new.around_consume_batch('batch', {}, &block) }
-      .to yield_with_no_args
-  end
-
-  it 'includes default "#before_consume_batch"' do
-    expect(TestIncludeBatchHandler.new.before_consume_batch('payloads', {})).to eq('payloads')
+      .to yield_with_args('batch', {})
   end
 
   describe '#consume_batch' do

--- a/spec/lib/phobos/handler_spec.rb
+++ b/spec/lib/phobos/handler_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Phobos::Handler do
 
   it 'includes default "#around_consume"' do
     expect { |block| TestIncludeHandler.new.around_consume('payload', {}, &block) }
-      .to yield_with_no_args
+      .to yield_with_args('payload', {})
   end
 
   describe '#consume' do


### PR DESCRIPTION
…ound_consume.

Fixes the first part of #84.

This is the first step to removing before_consume and making this much shinier and simpler in 2.x.