### PR TITLE
Version 2.0 - Remove deprecated behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ``
 ## UNRELEASED
 
+- Remove deprecated patterns:
+-- `before_consume` method
+-- `around_consume` as a class method or without yielding values
+-- `publish` and `async_publish` with positional arguments
+
 ## [1.9.0] - 2020-03-05
 - Bumped version to 1.9.0.
 
 ## [1.9.0-beta3] - 2020-02-05
+
 - Fix bug where deprecation errors would be shown when receiving nil payloads
   even if `around_consume` was updated to yield them.
+
 
 ## [1.9.0-beta2] - 2020-01-09
 

--- a/README.md
+++ b/README.md
@@ -197,8 +197,6 @@ class MyHandler
 end
 ```
 
-Note: Previous versions used a `before_consume` method to pre-process the payload. This is still supported, but deprecated. Going forward, `around_consume` should yield the payload and metadata back to the calling code, allowing it to act as a pre-processor, e.g. by decoding Avro messages into Ruby hashes.
-
 Take a look at the examples folder for some ideas.
 
 The hander life cycle can be illustrated as:
@@ -286,8 +284,6 @@ When publishing a message with headers, the `headers` argument must be a hash:
 my = MyProducer.new
 my.producer.publish(topic: 'topic', payload: 'message-payload', key: 'partition and message key', headers: { header_1: 'value 1' })
 ```
-
-Older versions of Phobos provided a `publish` method that accepted positional arguments. That version is still supported but it's soon to be deprecated in favour of the keyword arguments version.
 
 It is also possible to publish several messages at once:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ With Phobos by your side, all this becomes smooth sailing.
 ## Table of Contents
 
 1. [Installation](#installation)
-  1. [Upgrade Notes](#upgrade-notes)
 1. [Usage](#usage)
   1. [Standalone apps](#usage-standalone-apps)
   1. [Consuming messages from Kafka](#usage-consuming-messages-from-kafka)
@@ -32,6 +31,7 @@ With Phobos by your side, all this becomes smooth sailing.
 1. [Plugins](#plugins)
 1. [Development](#development)
 1. [Test](#test)
+1. [Upgrade Notes](#upgrade-notes)
 
 ## <a name="installation"></a> Installation
 
@@ -52,10 +52,6 @@ Or install it yourself as:
 ```sh
 $ gem install phobos
 ```
-
-### <a name="upgrade-notes"></a> Upgrade Notes
-
-Version 1.8.2 introduced a new `persistent_connections` setting for regular producers. This reduces the number of connections used to produce messages and you should consider setting it to true. This does require a manual shutdown call -  please see [Producers with persistent connections](#persistent-connection).
 
 ## <a name="usage"></a> Usage
 
@@ -614,6 +610,57 @@ describe MyConsumer do
   end
 end
 ```
+
+## <a name="upgrade-notes"></a> Upgrade Notes
+
+Version 2.0 removes deprecated ways of defining producers and consumers:
+* The `before_consume` method has been removed. You can have this behavior in the first part of an `around_consume` method.
+* `around_consume` is now only available as an instance method, and it must yield the values to pass to the `consume` method.
+* `publish` and `async_publish` now only accept keyword arguments, not positional arguments.
+
+Example pre-2.0:
+```ruby
+class MyHandler
+  include Phobos::Handler
+
+  def before_consume(payload, metadata)
+    payload[:id] = 1
+  end
+
+  def self.around_consume(payload, metadata)
+    metadata[:key] = 5
+    yield
+  end
+end
+```
+
+In 2.0:
+```ruby
+class MyHandler
+  include Phobos::Handler
+
+  def around_consume(payload, metadata)
+    new_payload = payload.dup
+    new_metadata = metadata.dup
+    new_payload[:id] = 1
+    new_metadata[:key] = 5
+    yield new_payload, new_metadata
+  end
+end
+```
+
+Producer, 1.9:
+```ruby
+  producer.publish('my-topic', { payload_value: 1}, 5, 3, {header_val: 5})
+```
+
+Producer 2.0:
+```ruby
+  producer.publish(topic: 'my-topic', payload: { payload_value: 1}, key: 5, 
+     partition_key: 3, headers: { header_val: 5})
+```
+
+Version 1.8.2 introduced a new `persistent_connections` setting for regular producers. This reduces the number of connections used to produce messages and you should consider setting it to true. This does require a manual shutdown call -  please see [Producers with persistent connections](#persistent-connection).
 
 ## Contributing
 

--- a/lib/phobos/actions/process_batch_inline.rb
+++ b/lib/phobos/actions/process_batch_inline.rb
@@ -47,32 +47,13 @@ module Phobos
         )
       end
 
-      def preprocess(batch, handler)
-        if handler.respond_to?(:before_consume_batch)
-          Phobos.deprecate('before_consume_batch is deprecated and will be removed in 2.0. \
-                            Use around_consume_batch and yield payloads and metadata objects.')
-          handler.before_consume_batch(batch, @metadata)
-        else
-          batch
-        end
-      end
-
       def process_batch(batch)
         instrument('listener.process_batch_inline', @metadata) do |_metadata|
           handler = @listener.handler_class.new
 
-          preprocessed_batch = preprocess(batch, handler)
-          consume_block = proc { |around_batch, around_metadata|
-            if around_batch
-              handler.consume_batch(around_batch, around_metadata)
-            else
-              Phobos.deprecate('Calling around_consume_batch without yielding payloads \
-                                and metadata is deprecated and will be removed in 2.0.')
-              handler.consume_batch(preprocessed_batch, @metadata)
-            end
-          }
-
-          handler.around_consume_batch(preprocessed_batch, @metadata, &consume_block)
+          handler.around_consume_batch(batch, @metadata) do |around_batch, around_metadata|
+            handler.consume_batch(around_batch, around_metadata)
+          end
         end
       end
     end

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -35,47 +35,12 @@ module Phobos
 
       private
 
-      def preprocess(payload, handler)
-        if handler.respond_to?(:before_consume)
-          Phobos.deprecate('before_consume is deprecated and will be removed in 2.0. \
-                            Use around_consume and yield payload and metadata objects.')
-          begin
-            handler.before_consume(payload, @metadata)
-          rescue ArgumentError
-            handler.before_consume(payload)
-          end
-        else
-          payload
-        end
-      end
-
-      def consume_block(payload, handler)
-        proc { |around_payload, around_metadata|
-          if around_metadata
-            handler.consume(around_payload, around_metadata)
-          else
-            Phobos.deprecate('Calling around_consume without yielding payload and metadata \
-                              is deprecated and will be removed in 2.0.')
-            handler.consume(payload, @metadata)
-          end
-        }
-      end
-
       def process_message(payload)
         instrument('listener.process_message', @metadata) do
           handler = @listener.handler_class.new
 
-          preprocessed_payload = preprocess(payload, handler)
-          block = consume_block(preprocessed_payload, handler)
-
-          if @listener.handler_class.respond_to?(:around_consume)
-            # around_consume class method implementation
-            Phobos.deprecate('around_consume has been moved to instance method, please update '\
-                             'your consumer. This will not be backwards compatible in the future.')
-            @listener.handler_class.around_consume(preprocessed_payload, @metadata, &block)
-          else
-            # around_consume instance method implementation
-            handler.around_consume(preprocessed_payload, @metadata, &block)
+          handler.around_consume(payload, @metadata) do |around_payload, around_metadata|
+            handler.consume(around_payload, around_metadata)
           end
         end
       end

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -21,18 +21,20 @@ module Phobos
         @host_obj = host_obj
       end
 
-      def publish(*args, **kwargs)
-        Phobos.deprecate(deprecate_positional_args_message('publish')) if kwargs.empty?
-
-        args = normalize_arguments(*args, **kwargs)
-        class_producer.publish(**args)
+      def publish(topic:, payload:, key: nil, partition_key: nil, headers: nil)
+        class_producer.publish(topic: topic,
+                               payload: payload,
+                               key: key,
+                               partition_key: partition_key,
+                               headers: headers)
       end
 
-      def async_publish(*args, **kwargs)
-        Phobos.deprecate(deprecate_positional_args_message('async_publish')) if kwargs.empty?
-
-        args = normalize_arguments(*args, **kwargs)
-        class_producer.async_publish(**args)
+      def async_publish(topic:, payload:, key: nil, partition_key: nil, headers: nil)
+        class_producer.async_publish(topic: topic,
+                                     payload: payload,
+                                     key: key,
+                                     partition_key: partition_key,
+                                     headers: headers)
       end
 
       # @param messages [Array(Hash(:topic, :payload, :key, :headers))]
@@ -53,36 +55,6 @@ module Phobos
 
       def class_producer
         @host_obj.class.producer
-      end
-
-      # rubocop:disable Metrics/ParameterLists
-      def normalize_arguments(p_topic = nil, p_payload = nil, p_key = nil,
-                              p_partition_key = nil, p_headers = {},
-                              **kwargs)
-        {}.tap do |args|
-          {
-            topic: p_topic,
-            payload: p_payload,
-            key: p_key,
-            partition_key: p_partition_key,
-            headers: p_headers
-          }.each { |k, v| args[k] = kwargs[k] || v }
-
-          raise MissingRequiredArgumentsError if [:topic, :payload].any? { |k| args[k].nil? }
-
-          kwargs.each do |k, v|
-            next if args.key?(k)
-
-            args[:headers][k] = v
-          end
-        end
-      end
-      # rubocop:enable Metrics/ParameterLists
-
-      def deprecate_positional_args_message(method_name)
-        "The `#{method_name}` method should now receive keyword arguments " \
-          'rather than positional ones. Please update your publishers. This will ' \
-          'not be backwards compatible in the future.'
       end
     end
 

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -11,12 +11,6 @@ module Phobos
     end
 
     class PublicAPI
-      MissingRequiredArgumentsError = Class.new(StandardError) do
-        def initialize
-          super('You need to provide a topic name and a payload')
-        end
-      end
-
       def initialize(host_obj)
         @host_obj = host_obj
       end

--- a/spec/lib/phobos/actions/process_batch_inline_spec.rb
+++ b/spec/lib/phobos/actions/process_batch_inline_spec.rb
@@ -104,39 +104,6 @@ RSpec.describe Phobos::Actions::ProcessBatchInline do
         topic: topic
       )
     end
-
-    it 'supports the method and logs a deprecation message' do
-      expect(Phobos).to receive(:deprecate).once
-      expect_any_instance_of(TestBatchHandler2).to receive(:around_consume_batch).
-        with(payloads, subject.metadata).once.and_call_original
-      expect_any_instance_of(TestBatchHandler2).to receive(:consume_batch).
-        with(payloads, subject.metadata).once.and_call_original
-
-      subject.execute
-    end
-  end
-
-  context 'with deprecated before_consume_batch' do
-    let(:listener) do
-      Phobos::Listener.new(
-        handler: TestBatchHandler3,
-        group_id: 'test-group',
-        topic: topic
-      )
-    end
-
-    it 'calls before_consume and deprecates' do
-      expect_any_instance_of(TestBatchHandler3).to receive(:around_consume_batch).
-        with(payloads, subject.metadata).once.and_call_original
-      expect(Phobos).to receive(:deprecate).once
-      expect_any_instance_of(TestBatchHandler3).to receive(:before_consume_batch).
-        with(payloads, subject.metadata).once.and_call_original
-      expect_any_instance_of(TestBatchHandler3).to receive(:consume_batch).
-        with(payloads, subject.metadata).once.and_call_original
-
-      subject.execute
-    end
-
   end
 
   context 'when processing fails' do

--- a/spec/lib/phobos/actions/process_message_spec.rb
+++ b/spec/lib/phobos/actions/process_message_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe Phobos::Actions::ProcessMessage do
   class TestHandler2 < Phobos::EchoHandler
     include Phobos::Handler
 
-    def before_consume(payload, _metadata)
-      payload
-    end
-
     def self.around_consume(payload, metadata)
       yield payload, metadata
     end
@@ -22,10 +18,6 @@ RSpec.describe Phobos::Actions::ProcessMessage do
 
   class TestHandler3 < Phobos::EchoHandler
     include Phobos::Handler
-
-    def before_consume(payload)
-      payload
-    end
   end
 
   class TestHandler4 < Phobos::EchoHandler
@@ -67,8 +59,7 @@ RSpec.describe Phobos::Actions::ProcessMessage do
     allow(subject).to receive(:sleep) # Prevent sleeping in tests
   end
 
-  it 'processes the message by calling around consume, before consume and consume of the handler' do
-    expect(Phobos).not_to receive(:deprecate)
+  it 'processes the message by calling around consume and consume of the handler' do
     expect_any_instance_of(TestHandler).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
     expect_any_instance_of(TestHandler).to receive(:consume).with(payload, subject.metadata).once.and_call_original
 
@@ -80,18 +71,17 @@ RSpec.describe Phobos::Actions::ProcessMessage do
     subject.execute
   end
 
-
-      subject.execute
+  context '.around_consumed defined' do
+    let(:listener) do
+      Phobos::Listener.new(
+        handler: TestHandler2,
+        group_id: 'test-group',
+        topic: topic
+      )
     end
+
   end
 
-  context '#around_consume with nil message' do
-    let(:payload) { nil }
-
-    it 'should not deprecate with nil payload' do
-      expect(Phobos).not_to receive(:deprecate)
-      expect_any_instance_of(TestHandler).to receive(:around_consume).with(nil, subject.metadata).once.and_call_original
-      expect_any_instance_of(TestHandler).to receive(:consume).with(nil, subject.metadata).once.and_call_original
   context 'with encoding' do
     let(:handler) { TestHandler.new }
     let(:force_encoding) { 'UTF-8' }

--- a/spec/lib/phobos/actions/process_message_spec.rb
+++ b/spec/lib/phobos/actions/process_message_spec.rb
@@ -80,20 +80,6 @@ RSpec.describe Phobos::Actions::ProcessMessage do
     subject.execute
   end
 
-  context '.around_consumed defined' do
-    let(:listener) do
-      Phobos::Listener.new(
-        handler: TestHandler2,
-        group_id: 'test-group',
-        topic: topic
-      )
-    end
-
-    it 'supports and prefers around_consume if defined as a class method' do
-      expect(TestHandler2).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
-      expect(Phobos).to receive(:deprecate).twice # before_consume and around_consume as class method
-      expect_any_instance_of(TestHandler2).to receive(:before_consume).with(payload, subject.metadata).once.and_call_original
-      expect_any_instance_of(TestHandler2).to receive(:consume).with(payload, subject.metadata).once.and_call_original
 
       subject.execute
     end
@@ -106,48 +92,6 @@ RSpec.describe Phobos::Actions::ProcessMessage do
       expect(Phobos).not_to receive(:deprecate)
       expect_any_instance_of(TestHandler).to receive(:around_consume).with(nil, subject.metadata).once.and_call_original
       expect_any_instance_of(TestHandler).to receive(:consume).with(nil, subject.metadata).once.and_call_original
-
-      subject.execute
-    end
-  end
-
-  context '#around_consume that does not yield arguments' do
-    let(:listener) do
-      Phobos::Listener.new(
-        handler: TestHandler4,
-        group_id: 'test-group',
-        topic: topic
-      )
-    end
-
-    it 'supports the method and logs a deprecation message' do
-      expect(Phobos).to receive(:deprecate).once
-      expect_any_instance_of(TestHandler4).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
-      expect_any_instance_of(TestHandler4).to receive(:consume).with(payload, subject.metadata).once.and_call_original
-
-      subject.execute
-    end
-  end
-
-  context '#before_consume defined with 1 argument' do
-    let(:listener) do
-      Phobos::Listener.new(
-        handler: TestHandler3,
-        group_id: 'test-group',
-        topic: topic
-      )
-    end
-
-    it 'supports the method and logs a deprecation message' do
-      expect(Phobos).to receive(:deprecate).once
-      expect_any_instance_of(TestHandler3).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
-      expect_any_instance_of(TestHandler3).to receive(:before_consume).with(payload).once.and_call_original
-      expect_any_instance_of(TestHandler3).to receive(:consume).with(payload, subject.metadata).once.and_call_original
-
-      subject.execute
-    end
-  end
-
   context 'with encoding' do
     let(:handler) { TestHandler.new }
     let(:force_encoding) { 'UTF-8' }

--- a/spec/lib/phobos/producer_spec.rb
+++ b/spec/lib/phobos/producer_spec.rb
@@ -18,64 +18,23 @@ RSpec.describe Phobos::Producer do
   let(:public_api) { Phobos::Producer::ClassMethods::PublicAPI.new }
 
   describe '#publish' do
-    it 'publishes a single message using "publish_list" when called with positional arguments' do
-      expect(TestProducer1.producer)
-        .to receive(:publish_list)
-        .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: nil, headers: {}}])
-
-      subject.producer.publish('topic', 'message', 'key')
-    end
-
-    it 'logs a deprecation message when called with positional arguments' do
-      expect(Phobos).to receive(:deprecate).with(
-        /The `publish` method should now receive keyword arguments rather than positional ones/
-      )
-
-      subject.producer.publish('topic', 'message', 'key')
-    end
-
-    it 'publishes a single message using "publish_list" when called with keyword arguments' do
+    it 'publishes a single message using "publish_list"' do
       expect(TestProducer1.producer)
         .to receive(:publish_list)
         .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: 'partition_key', headers: { foo: 'bar', fizz: 'buzz' } }])
 
-      subject.producer.publish(topic: 'topic', payload: 'message', key: 'key', partition_key: 'partition_key', foo: 'bar', fizz: 'buzz')
-    end
-
-    it 'raises an error if any of the required arguments is not provided' do
-      expect { subject.producer.publish }.to raise_error(described_class::PublicAPI::MissingRequiredArgumentsError)
+      subject.producer.publish(topic: 'topic', payload: 'message', key: 'key', partition_key: 'partition_key', headers: { foo: 'bar', fizz: 'buzz' })
     end
   end
 
   describe '#async_publish' do
-    it 'publishes a single message using "async_publish" when called with positional arguments' do
-      expect(TestProducer1.producer)
-        .to receive(:async_publish_list)
-        .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: nil, headers: { foo: 'bar', fizz: 'buzz' } }])
-
-      TestProducer1.producer.create_async_producer
-      subject.producer.async_publish('topic', 'message', 'key', nil, foo: 'bar', fizz: 'buzz')
-    end
-
-    it 'logs a deprecation message when called with positional arguments' do
-      expect(Phobos).to receive(:deprecate).with(
-        /The `async_publish` method should now receive keyword arguments rather than positional ones/
-      )
-
-      subject.producer.async_publish('topic', 'message', 'key')
-    end
-
-    it 'publishes a single message using "async_publish" when called with keyword arguments' do
+    it 'publishes a single message using "async_publish"' do
       expect(TestProducer1.producer)
         .to receive(:async_publish_list)
         .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: 'partition_key', headers: { foo: 'bar' } }])
 
       TestProducer1.producer.create_async_producer
       subject.producer.async_publish(topic: 'topic', payload: 'message', key: 'key', partition_key: 'partition_key', headers: { foo: 'bar' })
-    end
-
-    it 'raises an error if any of the required arguments is not provided' do
-      expect { subject.producer.async_publish }.to raise_error(described_class::PublicAPI::MissingRequiredArgumentsError)
     end
   end
 

--- a/spec/lib/phobos/test/helper_spec.rb
+++ b/spec/lib/phobos/test/helper_spec.rb
@@ -36,11 +36,6 @@ RSpec.describe Phobos::Test::Helper do
       process_message(handler: TestHelperHandler, payload: payload)
     end
 
-    it 'invokes handler before_consume with payload' do
-      expect_any_instance_of(TestHelperHandler).to receive(:before_consume).with(payload, listener_metadata)
-      process_message(handler: TestHelperHandler, payload: payload)
-    end
-
     it 'invokes handler consume with payload and metadata' do
       expect_any_instance_of(TestHelperHandler).to receive(:consume).with(payload, hash_including(metadata))
       process_message(handler: TestHelperHandler, payload: payload, metadata: metadata)


### PR DESCRIPTION
@klippx @cassiomarques here it is! Let me know what you think!

I'll create a 1.9.x branch off master before merging this so we can support existing versions long-term.

To clarify, this removes the following patterns:
* `before_consume` method
* `around_consume` as a class method or without yielding values
* `publish` and `async_publish` with positional arguments

We have instead standardized on `around_consume` as an instance method that then yields the values to the `consume` method - so we don't force mutations and have both methods be instance methods.

We also moved to keyword arguments for publishing since the publish methods now have more than the recommended number of arguments and are becoming difficult to use.