### PR TITLE
Fix deprecation message when nil payloads are used

### DIFF
--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -51,7 +51,7 @@ module Phobos
 
       def consume_block(payload, handler)
         proc { |around_payload, around_metadata|
-          if around_payload
+          if around_metadata
             handler.consume(around_payload, around_metadata)
           else
             Phobos.deprecate('Calling around_consume without yielding payload and metadata \

--- a/spec/lib/phobos/actions/process_batch_spec.rb
+++ b/spec/lib/phobos/actions/process_batch_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Phobos::Actions::ProcessBatch do
-  class TestHandler < Phobos::EchoHandler
+  class TestProcessBatchHandler < Phobos::EchoHandler
     include Phobos::Handler
   end
 
@@ -11,7 +11,7 @@ RSpec.describe Phobos::Actions::ProcessBatch do
   let(:topic) { 'test-topic' }
   let(:listener) do
     Phobos::Listener.new(
-      handler: TestHandler,
+      handler: TestProcessBatchHandler,
       group_id: 'test-group',
       topic: topic
     )

--- a/spec/lib/phobos/actions/process_message_spec.rb
+++ b/spec/lib/phobos/actions/process_message_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Phobos::Actions::ProcessMessage do
   end
 
   it 'processes the message by calling around consume, before consume and consume of the handler' do
+    expect(Phobos).not_to receive(:deprecate)
     expect_any_instance_of(TestHandler).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
     expect_any_instance_of(TestHandler).to receive(:consume).with(payload, subject.metadata).once.and_call_original
 
@@ -93,6 +94,18 @@ RSpec.describe Phobos::Actions::ProcessMessage do
       expect(Phobos).to receive(:deprecate).twice # before_consume and around_consume as class method
       expect_any_instance_of(TestHandler2).to receive(:before_consume).with(payload, subject.metadata).once.and_call_original
       expect_any_instance_of(TestHandler2).to receive(:consume).with(payload, subject.metadata).once.and_call_original
+
+      subject.execute
+    end
+  end
+
+  context '#around_consume with nil message' do
+    let(:payload) { nil }
+
+    it 'should not deprecate with nil payload' do
+      expect(Phobos).not_to receive(:deprecate)
+      expect_any_instance_of(TestHandler).to receive(:around_consume).with(nil, subject.metadata).once.and_call_original
+      expect_any_instance_of(TestHandler).to receive(:consume).with(nil, subject.metadata).once.and_call_original
 
       subject.execute
     end

--- a/spec/lib/phobos/test/helper_spec.rb
+++ b/spec/lib/phobos/test/helper_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'phobos/test/helper'
 
 RSpec.describe Phobos::Test::Helper do
-  class TestHandler < Phobos::EchoHandler
+  class TestHelperHandler < Phobos::EchoHandler
     include Phobos::Handler
     CONSUME_VISITED = 'consume was visited'
 
@@ -33,22 +33,22 @@ RSpec.describe Phobos::Test::Helper do
         .to receive(:instrument)
         .with('listener.process_message', Hash)
 
-      process_message(handler: TestHandler, payload: payload)
+      process_message(handler: TestHelperHandler, payload: payload)
     end
 
     it 'invokes handler before_consume with payload' do
-      expect_any_instance_of(TestHandler).to receive(:before_consume).with(payload, listener_metadata)
-      process_message(handler: TestHandler, payload: payload)
+      expect_any_instance_of(TestHelperHandler).to receive(:before_consume).with(payload, listener_metadata)
+      process_message(handler: TestHelperHandler, payload: payload)
     end
 
     it 'invokes handler consume with payload and metadata' do
-      expect_any_instance_of(TestHandler).to receive(:consume).with(payload, hash_including(metadata))
-      process_message(handler: TestHandler, payload: payload, metadata: metadata)
+      expect_any_instance_of(TestHelperHandler).to receive(:consume).with(payload, hash_including(metadata))
+      process_message(handler: TestHelperHandler, payload: payload, metadata: metadata)
     end
 
     it 'returns the result of the handler consume method' do
-      expect(process_message(handler: TestHandler, payload: payload))
-        .to eq TestHandler::CONSUME_VISITED
+      expect(process_message(handler: TestHelperHandler, payload: payload))
+        .to eq TestHelperHandler::CONSUME_VISITED
     end
   end
 end


### PR DESCRIPTION
Right now it checks `around_batch` / `around_payload` to see if it should print a deprecation message. However, these can legitimately be nil. Metadata should never be nil so this is a more accurate approach to see whether to print the message.