### PR TITLE
Use topic from message in metadata

### DIFF
--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -13,6 +13,7 @@ module Phobos
         @listener = listener
         @message = message
         @metadata = listener_metadata.merge(
+          topic: message.topic,
           key: message.key,
           partition: message.partition,
           offset: message.offset,


### PR DESCRIPTION
Metadata by default has the topic from the listener.  If the listener
uses a regex to listen to multiple topics, the topic in the metadata
ends up being the regex, and not the actual topic of the message.  This
makes is impossible to have a listener subscribe to multiple topics but
fine tune the behavior based on the actual topic on which the message
came.

For instance, an indexing service might look for updates on multiple
topics, but needs to know the actual topic to adjust the right index.

The underlying message from the Kafka library has the actual topic.
We can use it to populate the metadata.