### PR TITLE
Allow actual YAML/PSYCH versions to be supported

### DIFF
--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -114,14 +114,25 @@ module Phobos
     def read_configuration(configuration)
       return configuration.to_h if configuration.respond_to?(:to_h)
 
-      YAML.safe_load(
-        ERB.new(
-          File.read(File.expand_path(configuration))
-        ).result,
-        [Symbol],
-        [],
-        true
-      )
+      if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
+        YAML.safe_load(
+          ERB.new(
+            File.read(File.expand_path(configuration))
+          ).result,
+          permitted_classes: [Symbol],
+          permitted_symbols: [],
+          aliases: true
+        )
+      else
+        YAML.safe_load(
+          ERB.new(
+            File.read(File.expand_path(configuration))
+          ).result,
+          [Symbol],
+          [],
+          true
+        )
+      end
     end
 
     def configure_phobos_logger


### PR DESCRIPTION
This will allow Psych::VERSION > '3.1.0.pre1' to be supported (is used by YAML.safe_load).

( See https://ruby-doc.org/stdlib-3.1.0/libdoc/psych/rdoc/index.html - Ruby 3.1.0 )