### PR TITLE
process_batch action catches runtime error on heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ``
 ## UNRELEASED
 
+- Rescue and log Kafka::HeartbeatError in batch processing
+
 ## [2.1.2] - 2022-01-27
 
 - Fix packaging error.

--- a/lib/phobos/actions/process_batch.rb
+++ b/lib/phobos/actions/process_batch.rb
@@ -4,6 +4,7 @@ module Phobos
   module Actions
     class ProcessBatch
       include Phobos::Instrumentation
+      include Phobos::Log
 
       attr_reader :metadata
 
@@ -26,7 +27,11 @@ module Phobos
               message: message,
               listener_metadata: @listener_metadata
             ).execute
-            @listener.consumer.trigger_heartbeat
+            begin
+              @listener.consumer.trigger_heartbeat
+            rescue Kafka::HeartbeatError => e
+              log_warn("Error sending Heartbeat #{e.class.name}-#{e}")
+            end
           end
         end
       end

--- a/lib/phobos/log.rb
+++ b/lib/phobos/log.rb
@@ -13,6 +13,10 @@ module Phobos
     def log_error(msg, metadata)
       LoggerHelper.log(:error, msg, metadata)
     end
+
+    def log_warn(msg, metadata = {})
+      LoggerHelper.log(:warn, msg, metadata)
+    end
   end
 
   module LoggerHelper

--- a/spec/lib/phobos/actions/process_batch_spec.rb
+++ b/spec/lib/phobos/actions/process_batch_spec.rb
@@ -59,4 +59,13 @@ RSpec.describe Phobos::Actions::ProcessBatch do
 
     subject.execute
   end
+
+  it 'is expected to catch HeartbeatError from trigger_heartbeat' do
+    consumer = listener.send(:create_kafka_consumer)
+    allow(listener).to receive(:consumer).and_return(consumer)
+    allow(listener.consumer).to receive(:trigger_heartbeat).and_raise(Kafka::HeartbeatError, 'Kafka::RebalanceInProgress')
+
+    expect{ subject.execute }.to_not raise_error
+  end
+
 end


### PR DESCRIPTION
#152 Heartbeat error is manifested into Processing error even though it's not a ProcessingError.
This catches heartbeat error and logs a warning message.

I think phobos cannot take any action based on this heartbeat response. It happens at consumer level in ruby-kafka so it's best to log as a warning instead of an error indicating that something happened.