### PR TITLE
Raise exception so that executor restarts the thread

### DIFF
--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -42,12 +42,14 @@ module Phobos
 
     def start
       @signal_to_stop = false
+      error = nil
 
       start_listener
 
       begin
         start_consumer_loop
-      rescue Kafka::ProcessingError, Phobos::AbortError
+      rescue Kafka::ProcessingError, Phobos::AbortError => e
+        error = e
         # Abort is an exception to prevent the consumer from committing the offset.
         # Since "listener" had a message being retried while "stop" was called
         # it's wise to not commit the batch offset to avoid data loss. This will
@@ -58,6 +60,7 @@ module Phobos
       end
     ensure
       stop_listener
+      raise error if error
     end
 
     def stop

--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -42,14 +42,11 @@ module Phobos
 
     def start
       @signal_to_stop = false
-      error = nil
-
       start_listener
 
       begin
         start_consumer_loop
       rescue Kafka::ProcessingError, Phobos::AbortError => e
-        error = e if e.is_a?(Kafka::ProcessingError)
         # Abort is an exception to prevent the consumer from committing the offset.
         # Since "listener" had a message being retried while "stop" was called
         # it's wise to not commit the batch offset to avoid data loss. This will
@@ -57,10 +54,10 @@ module Phobos
         instrument('listener.retry_aborted', listener_metadata) do
           log_info('Retry loop aborted, listener is shutting down', listener_metadata)
         end
+        raise e if e.is_a?(Kafka::ProcessingError)
       end
     ensure
       stop_listener
-      raise error if error
     end
 
     def stop

--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -49,7 +49,7 @@ module Phobos
       begin
         start_consumer_loop
       rescue Kafka::ProcessingError, Phobos::AbortError => e
-        error = e
+        error = e if e.is_a?(Kafka::ProcessingError)
         # Abort is an exception to prevent the consumer from committing the offset.
         # Since "listener" had a message being retried while "stop" was called
         # it's wise to not commit the batch offset to avoid data loss. This will


### PR DESCRIPTION
We are seeing issues where a crash on business logic within a consumer causes that listener thread to crash and never come back. This seems to be because the error gets propagated all the way down to RubyKafka, which raises a ProcessingError, which is then *caught* by Phobos and swallowed. The listener is shut down and doesn't come back.

This PR re-raises the exception so that the executor can call `handle_crashed_listener`.